### PR TITLE
Add Object class methods

### DIFF
--- a/benchmarks/Object/class.yml
+++ b/benchmarks/Object/class.yml
@@ -1,0 +1,5 @@
+---
+benchmark:
+- name: Object#class
+  script: obj.class
+  prelude: obj = Object.new

--- a/benchmarks/Object/clone.yml
+++ b/benchmarks/Object/clone.yml
@@ -1,0 +1,5 @@
+---
+benchmark:
+- name: Object#clone
+  script: obj.clone
+  prelude: obj = Object.new

--- a/benchmarks/Object/cmp.yml
+++ b/benchmarks/Object/cmp.yml
@@ -1,0 +1,10 @@
+---
+benchmark:
+- name: Object#<=>(self)
+  script: obj <=> obj
+  prelude: obj = Object.new
+- name: Object#<=>(other)
+  script: obj1 <=> obj2
+  prelude: |
+    obj1 = Object.new
+    obj2 = Object.new

--- a/benchmarks/Object/dup.yml
+++ b/benchmarks/Object/dup.yml
@@ -1,0 +1,5 @@
+---
+benchmark:
+- name: Object#dup
+  script: obj.dup
+  prelude: obj = Object.new

--- a/benchmarks/Object/enum_for.yml
+++ b/benchmarks/Object/enum_for.yml
@@ -1,0 +1,5 @@
+---
+benchmark:
+- name: Object#enum_for
+  script: str.enum_for(:each_byte)
+  prelude: str = "xyz"

--- a/benchmarks/Object/eql.yml
+++ b/benchmarks/Object/eql.yml
@@ -1,0 +1,10 @@
+---
+benchmark:
+- name: Object#eql?(self)
+  script: obj.eql?(obj)
+  prelude: obj = Object.new
+- name: Object#eql?(other)
+  script: obj1.eql?(obj2)
+  prelude: |
+    obj1 = Object.new
+    obj2 = Object.new

--- a/benchmarks/Object/equal.yml
+++ b/benchmarks/Object/equal.yml
@@ -1,0 +1,10 @@
+---
+benchmark:
+- name: Object#===(self)
+  script: obj === obj
+  prelude: obj = Object.new
+- name: Object#===(other)
+  script: obj1 === obj2
+  prelude: |
+    obj1 = Object.new
+    obj2 = Object.new

--- a/benchmarks/Object/extend.yml
+++ b/benchmarks/Object/extend.yml
@@ -1,0 +1,15 @@
+---
+prelude: |
+  module Calc
+    def add(x, y)
+      x + y
+    end
+
+    def double
+      self * 2
+    end
+  end
+benchmark:
+- name: Object#extend
+  script: obj.extend(Calc)
+  prelude: obj = "hello"

--- a/benchmarks/Object/inspect.yml
+++ b/benchmarks/Object/inspect.yml
@@ -1,0 +1,5 @@
+---
+benchmark:
+- name: Object#inspect
+  script: obj.inspect
+  prelude: obj = Object.new

--- a/benchmarks/Object/instance_of.yml
+++ b/benchmarks/Object/instance_of.yml
@@ -1,0 +1,8 @@
+---
+benchmark:
+- name: Object#instance_of?(class)
+  script: obj.instance_of?(Object)
+  prelude: obj = Object.new
+- name: Object#instance_of?(other_class)
+  script: obj.instance_of?(String)
+  prelude: obj = Object.new

--- a/benchmarks/Object/instance_variable_defined.yml
+++ b/benchmarks/Object/instance_variable_defined.yml
@@ -1,0 +1,20 @@
+---
+prelude: |
+  class Foo
+    def initialize
+      @x = true
+    end
+  end
+benchmark:
+- name: Object#instance_variable_defined?(defined_string)
+  script: obj.instance_variable_defined?("@x")
+  prelude: obj = Foo.new
+- name: Object#instance_variable_defined?(undefined_string)
+  script: obj.instance_variable_defined?("@y")
+  prelude: obj = Foo.new
+- name: Object#instance_variable_defined?(defined_symbol)
+  script: obj.instance_variable_defined?(:@x)
+  prelude: obj = Foo.new
+- name: Object#instance_variable_defined?(undefined_symbol)
+  script: obj.instance_variable_defined?(:@y)
+  prelude: obj = Foo.new

--- a/benchmarks/Object/instance_variable_get.yml
+++ b/benchmarks/Object/instance_variable_get.yml
@@ -1,0 +1,14 @@
+---
+prelude: |
+  class Foo
+    def initialize
+      @x = true
+    end
+  end
+benchmark:
+- name: Object#instance_variable_get(defined_string)
+  script: obj.instance_variable_get("@x")
+  prelude: obj = Foo.new
+- name: Object#instance_variable_get(defined_symbol)
+  script: obj.instance_variable_get(:@x)
+  prelude: obj = Foo.new

--- a/benchmarks/Object/instance_variable_set.yml
+++ b/benchmarks/Object/instance_variable_set.yml
@@ -1,0 +1,8 @@
+---
+benchmark:
+- name: Object#instance_variable_set(symbol, obj)
+  script: obj.instance_variable_set(:@x, :foobarbaz)
+  prelude: obj = Object.new
+- name: Object#instance_variable_set(string, obj)
+  script: obj.instance_variable_set("@x", :foobarbaz)
+  prelude: obj = Object.new

--- a/benchmarks/Object/instance_variables.yml
+++ b/benchmarks/Object/instance_variables.yml
@@ -1,0 +1,11 @@
+---
+prelude: |
+  class Foo
+    def initialize
+      @x = @y = @z = true
+    end
+  end
+benchmark:
+- name: Object#instance_variables
+  script: obj.instance_variables
+  prelude: obj = Object.new

--- a/benchmarks/Object/is_a.yml
+++ b/benchmarks/Object/is_a.yml
@@ -1,0 +1,14 @@
+---
+benchmark:
+- name: Object#is_a?(class)
+  script: obj.is_a?(Object)
+  prelude: obj = Object.new
+- name: Object#is_a?(other_class)
+  script: obj.is_a?(String)
+  prelude: obj = Object.new
+- name: Object#kind_of?(class)
+  script: obj.kind_of?(Object)
+  prelude: obj = Object.new
+- name: Object#kind_of?(other_class)
+  script: obj.kind_of?(String)
+  prelude: obj = Object.new

--- a/benchmarks/Object/itself.yml
+++ b/benchmarks/Object/itself.yml
@@ -3,3 +3,4 @@ benchmark:
 - name: Object#itself
   script: obj.itself
   prelude: obj = Object.new
+  required_ruby_version: 2.2

--- a/benchmarks/Object/itself.yml
+++ b/benchmarks/Object/itself.yml
@@ -1,0 +1,5 @@
+---
+benchmark:
+- name: Object#itself
+  script: obj.itself
+  prelude: obj = Object.new

--- a/benchmarks/Object/match.yml
+++ b/benchmarks/Object/match.yml
@@ -1,0 +1,7 @@
+---
+benchmark:
+- name: Object#=~(other)
+  script: obj1 =~ obj2
+  prelude: |
+    obj1 = Object.new
+    obj2 = Object.new

--- a/benchmarks/Object/method.yml
+++ b/benchmarks/Object/method.yml
@@ -1,0 +1,11 @@
+---
+prelude: |
+  class Foo
+    def hello
+      "Hello world!"
+    end
+  end
+benchmark:
+- name: Object#method(symbol)
+  script: obj.method(:hello)
+  prelude: obj = Foo.new

--- a/benchmarks/Object/methods.yml
+++ b/benchmarks/Object/methods.yml
@@ -1,0 +1,8 @@
+---
+benchmark:
+- name: Object#methods(true)
+  script: obj.methods(true)
+  prelude: obj = Object.new
+- name: Object#methods(false)
+  script: obj.methods(false)
+  prelude: obj = Object.new

--- a/benchmarks/Object/nil.yml
+++ b/benchmarks/Object/nil.yml
@@ -1,0 +1,5 @@
+---
+benchmark:
+- name: Object#nil?
+  script: obj.nil?
+  prelude: obj = Object.new

--- a/benchmarks/Object/not_equal.yml
+++ b/benchmarks/Object/not_equal.yml
@@ -1,0 +1,10 @@
+---
+benchmark:
+- name: Object#!=(self)
+  script: obj != obj
+  prelude: obj = Object.new
+- name: Object#!=(other)
+  script: obj1 != obj2
+  prelude: |
+    obj1 = Object.new
+    obj2 = Object.new

--- a/benchmarks/Object/object_id.yml
+++ b/benchmarks/Object/object_id.yml
@@ -1,0 +1,8 @@
+---
+benchmark:
+- name: Object#object_id
+  script: obj.object_id
+  prelude: obj = Object.new
+- name: Object#__id__
+  script: obj.__id__
+  prelude: obj = Object.new

--- a/benchmarks/Object/private_methods.yml
+++ b/benchmarks/Object/private_methods.yml
@@ -1,0 +1,8 @@
+---
+benchmark:
+- name: Object#private_methods(true)
+  script: obj.private_methods(true)
+  prelude: obj = Object.new
+- name: Object#private_methods(false)
+  script: obj.private_methods(false)
+  prelude: obj = Object.new

--- a/benchmarks/Object/protected_methods.yml
+++ b/benchmarks/Object/protected_methods.yml
@@ -1,0 +1,8 @@
+---
+benchmark:
+- name: Object#protected_methods(true)
+  script: obj.protected_methods(true)
+  prelude: obj = Object.new
+- name: Object#protected_methods(false)
+  script: obj.protected_methods(false)
+  prelude: obj = Object.new

--- a/benchmarks/Object/public_method.yml
+++ b/benchmarks/Object/public_method.yml
@@ -1,0 +1,5 @@
+---
+benchmark:
+- name: Object#public_method(symbol)
+  script: obj.public_method(:inspect)
+  prelude: obj = Object.new

--- a/benchmarks/Object/public_methods.yml
+++ b/benchmarks/Object/public_methods.yml
@@ -1,0 +1,8 @@
+---
+benchmark:
+- name: Object#public_methods(true)
+  script: obj.public_methods(true)
+  prelude: obj = Object.new
+- name: Object#public_methods(false)
+  script: obj.public_methods(false)
+  prelude: obj = Object.new

--- a/benchmarks/Object/public_send.yml
+++ b/benchmarks/Object/public_send.yml
@@ -1,0 +1,14 @@
+---
+benchmark:
+- name: Object#public_send(symbol)
+  script: obj.public_send(:nil?)
+  prelude: obj = Object.new
+- name: Object#public_send(symbol, arg)
+  script: obj.public_send(:==, 1)
+  prelude: obj = Object.new
+- name: Object#public_send(string)
+  script: obj.public_send("nil?")
+  prelude: obj = Object.new
+- name: Object#public_send(string, arg)
+  script: obj.public_send("==", 1)
+  prelude: obj = Object.new

--- a/benchmarks/Object/remove_instance_variable.yml
+++ b/benchmarks/Object/remove_instance_variable.yml
@@ -1,0 +1,14 @@
+---
+prelude: |
+  class Foo
+    def initialize
+      @x = true
+    end
+  end
+benchmark:
+- name: Object#remove_instance_variable(symbol)
+  script: obj.dup.remove_instance_variable(:@x)
+  prelude: obj = Foo.new
+- name: Object#remove_instance_variable(string)
+  script: obj.dup.remove_instance_variable("@x")
+  prelude: obj = Foo.new

--- a/benchmarks/Object/respond_to.yml
+++ b/benchmarks/Object/respond_to.yml
@@ -1,0 +1,37 @@
+---
+prelude: |
+  class Foo
+    def hello
+      "Hello world"
+    end
+
+    private
+    def add(x, y)
+      x + y
+    end
+  end
+
+  class Bar
+    def respond_to_missing?(name, private)
+      true
+    end
+  end
+benchmark:
+- name: Object#respond_to?(symbol)
+  script: foo.respond_to?(:hello)
+  prelude: foo = Foo.new
+- name: Object#respond_to?(symbol, true)
+  script: foo.respond_to?(:add, true)
+  prelude: foo = Foo.new
+- name: Object#respond_to?(symbol) with respond_to_missing
+  script: bar.respond_to?(:xxxx)
+  prelude: bar = Bar.new
+- name: Object#respond_to?(string)
+  script: foo.respond_to?("hello")
+  prelude: foo = Foo.new
+- name: Object#respond_to?(string, true)
+  script: foo.respond_to?("add", true)
+  prelude: foo = Foo.new
+- name: Object#respond_to?(string) with respond_to_missing
+  script: bar.respond_to?("xxxx")
+  prelude: bar = Bar.new

--- a/benchmarks/Object/send.yml
+++ b/benchmarks/Object/send.yml
@@ -1,0 +1,14 @@
+---
+benchmark:
+- name: Object#send(symbol)
+  script: obj.send(:nil?)
+  prelude: obj = Object.new
+- name: Object#send(symbol, arg)
+  script: obj.send(:==, 1)
+  prelude: obj = Object.new
+- name: Object#send(string)
+  script: obj.send("nil?")
+  prelude: obj = Object.new
+- name: Object#send(string, arg)
+  script: obj.send("==", 1)
+  prelude: obj = Object.new

--- a/benchmarks/Object/singleton_class.yml
+++ b/benchmarks/Object/singleton_class.yml
@@ -1,0 +1,5 @@
+---
+benchmark:
+- name: Object#singleton_class
+  script: obj.singleton_class
+  prelude: obj = Object.new

--- a/benchmarks/Object/singleton_method.yml
+++ b/benchmarks/Object/singleton_method.yml
@@ -1,0 +1,16 @@
+---
+benchmark:
+- name: Object#singleton_method(symbol)
+  script: obj.singleton_method(:hello)
+  prelude: |
+    obj = Object.new
+    def obj.hello
+      "Hello world"
+    end
+- name: Object#singleton_method(string)
+  script: obj.singleton_method("hello")
+  prelude: |
+    obj = Object.new
+    def obj.hello
+      "Hello world"
+    end

--- a/benchmarks/Object/singleton_methods.yml
+++ b/benchmarks/Object/singleton_methods.yml
@@ -1,0 +1,28 @@
+---
+prelude: |
+  module Calc
+    def add(x, y)
+      x + y
+    end
+
+    def double
+      self * 2
+    end
+  end
+benchmark:
+- name: Object#singleton_methods
+  script: obj.singleton_methods
+  prelude: |
+    obj = "hello"
+    obj.extend(Calc)
+    def obj.triple
+      self * 3
+    end
+- name: Object#singleton_methods(false)
+  script: obj.singleton_methods(false)
+  prelude: |
+    obj = "hello"
+    obj.extend(Calc)
+    def obj.triple
+      self * 3
+    end

--- a/benchmarks/Object/tap.yml
+++ b/benchmarks/Object/tap.yml
@@ -1,0 +1,5 @@
+---
+benchmark:
+- name: Object#tap { |x| ...}
+  script: obj.tap { |x| }
+  prelude: obj = Object.new

--- a/benchmarks/Object/to_s.yml
+++ b/benchmarks/Object/to_s.yml
@@ -1,0 +1,5 @@
+---
+benchmark:
+- name: Object#to_s
+  script: obj.to_s
+  prelude: obj = Object.new

--- a/benchmarks/Object/yield_self.yml
+++ b/benchmarks/Object/yield_self.yml
@@ -3,3 +3,4 @@ benchmark:
 - name: Object#yield_self { |x| ...}
   script: obj.yield_self { |x| }
   prelude: obj = Object.new
+  required_ruby_version: 2.5

--- a/benchmarks/Object/yield_self.yml
+++ b/benchmarks/Object/yield_self.yml
@@ -1,0 +1,5 @@
+---
+benchmark:
+- name: Object#yield_self { |x| ...}
+  script: obj.yield_self { |x| }
+  prelude: obj = Object.new


### PR DESCRIPTION
This PR adds benchmarks of methods in Object as following list.
The following list is based on https://ruby-doc.org/core-2.5.1/Object.html

- [x] #!~
- [x] #<=>
- [x] #===
- [x] #=~
- [x] #class
- [x] #clone
- [ ] #define_singleton_method
- [ ] #display
- [x] #dup
- [x] #enum_for
- [x] #eql?
- [x] #extend
- [ ] #freeze
- [ ] #frozen?
- [x] #inspect
- [x] #instance_of?
- [x] #instance_variable_defined?
- [x] #instance_variable_get
- [x] #instance_variable_set
- [x] #instance_variables
- [x] #is_a?
- [x] #itself
- [x] #kind_of?
- [x] #method
- [x] #methods
- [x] #nil?
- [x] #object_id
- [x] #private_methods
- [x] #protected_methods
- [x] #public_method
- [x] #public_methods
- [x] #public_send
- [x] #remove_instance_variable
- [x] #respond_to?
- [x] #send
- [x] #singleton_class
- [x] #singleton_method
- [x] #singleton_methods
- [ ] #taint
- [ ] #tainted?
- [x] #tap
- [x] #to_enum
- [x] #to_s
- [ ] #trust
- [ ] #untaint
- [ ] #untrust
- [ ] #untrusted?
- [x] #yield_self